### PR TITLE
deps!: update interface deps to use byte lists

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
   "dependencies": {
     "@libp2p/crypto": "^1.0.0",
     "@libp2p/interface-peer-id": "^1.0.2",
-    "@libp2p/interface-record": "^1.0.1",
+    "@libp2p/interface-record": "^2.0.0",
     "@libp2p/logger": "^2.0.0",
     "@libp2p/peer-id": "^1.1.13",
     "@libp2p/utils": "^3.0.0",
@@ -160,16 +160,18 @@
     "it-map": "^1.0.6",
     "it-pipe": "^2.0.3",
     "multiformats": "^9.6.3",
-    "protons-runtime": "^1.0.4",
+    "protons-runtime": "^2.0.2",
+    "uint8-varint": "^1.0.2",
+    "uint8arraylist": "^2.1.0",
     "uint8arrays": "^3.0.0",
     "varint": "^6.0.0"
   },
   "devDependencies": {
-    "@libp2p/interface-record-compliance-tests": "^1.0.0",
+    "@libp2p/interface-record-compliance-tests": "^2.0.0",
     "@libp2p/peer-id-factory": "^1.0.0",
     "@types/varint": "^6.0.0",
     "aegir": "^37.3.0",
-    "protons": "^3.0.4",
+    "protons": "^4.0.1",
     "sinon": "^14.0.0"
   }
 }

--- a/src/envelope/envelope.ts
+++ b/src/envelope/envelope.ts
@@ -3,6 +3,7 @@
 
 import { encodeMessage, decodeMessage, message, bytes } from 'protons-runtime'
 import type { Codec } from 'protons-runtime'
+import type { Uint8ArrayList } from 'uint8arraylist'
 
 export interface Envelope {
   publicKey: Uint8Array
@@ -21,11 +22,11 @@ export namespace Envelope {
     })
   }
 
-  export const encode = (obj: Envelope): Uint8Array => {
+  export const encode = (obj: Envelope): Uint8ArrayList => {
     return encodeMessage(obj, Envelope.codec())
   }
 
-  export const decode = (buf: Uint8Array): Envelope => {
+  export const decode = (buf: Uint8Array | Uint8ArrayList): Envelope => {
     return decodeMessage(buf, Envelope.codec())
   }
 }

--- a/src/peer-record/index.ts
+++ b/src/peer-record/index.ts
@@ -7,6 +7,7 @@ import {
   ENVELOPE_DOMAIN_PEER_RECORD,
   ENVELOPE_PAYLOAD_TYPE_PEER_RECORD
 } from './consts.js'
+import type { Uint8ArrayList } from 'uint8arraylist'
 
 export interface PeerRecordInit {
   peerId: PeerId
@@ -30,7 +31,7 @@ export class PeerRecord {
   /**
    * Unmarshal Peer Record Protobuf
    */
-  static createFromProtobuf = (buf: Uint8Array): PeerRecord => {
+  static createFromProtobuf = (buf: Uint8Array | Uint8ArrayList): PeerRecord => {
     const peerRecord = Protobuf.decode(buf)
     const peerId = peerIdFromBytes(peerRecord.peerId)
     const multiaddrs = (peerRecord.addresses ?? []).map((a) => new Multiaddr(a.multiaddr))
@@ -47,7 +48,7 @@ export class PeerRecord {
   public seqNumber: bigint
   public domain = PeerRecord.DOMAIN
   public codec = PeerRecord.CODEC
-  private marshaled?: Uint8Array
+  private marshaled?: Uint8ArrayList
 
   constructor (init: PeerRecordInit) {
     const { peerId, multiaddrs, seqNumber } = init

--- a/src/peer-record/peer-record.ts
+++ b/src/peer-record/peer-record.ts
@@ -3,6 +3,7 @@
 
 import { encodeMessage, decodeMessage, message, bytes, uint64 } from 'protons-runtime'
 import type { Codec } from 'protons-runtime'
+import type { Uint8ArrayList } from 'uint8arraylist'
 
 export interface PeerRecord {
   peerId: Uint8Array
@@ -22,11 +23,11 @@ export namespace PeerRecord {
       })
     }
 
-    export const encode = (obj: AddressInfo): Uint8Array => {
+    export const encode = (obj: AddressInfo): Uint8ArrayList => {
       return encodeMessage(obj, AddressInfo.codec())
     }
 
-    export const decode = (buf: Uint8Array): AddressInfo => {
+    export const decode = (buf: Uint8Array | Uint8ArrayList): AddressInfo => {
       return decodeMessage(buf, AddressInfo.codec())
     }
   }
@@ -39,11 +40,11 @@ export namespace PeerRecord {
     })
   }
 
-  export const encode = (obj: PeerRecord): Uint8Array => {
+  export const encode = (obj: PeerRecord): Uint8ArrayList => {
     return encodeMessage(obj, PeerRecord.codec())
   }
 
-  export const decode = (buf: Uint8Array): PeerRecord => {
+  export const decode = (buf: Uint8Array | Uint8ArrayList): PeerRecord => {
     return decodeMessage(buf, PeerRecord.codec())
   }
 }

--- a/test/envelope.spec.ts
+++ b/test/envelope.spec.ts
@@ -1,11 +1,11 @@
 import { expect } from 'aegir/chai'
 import { fromString as uint8arrayFromString } from 'uint8arrays/from-string'
-import { equals as uint8arrayEquals } from 'uint8arrays/equals'
 import { RecordEnvelope } from '../src/envelope/index.js'
 import { codes as ErrorCodes } from '../src/errors.js'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import type { Record } from '@libp2p/interface-record'
 import type { PeerId } from '@libp2p/interface-peer-id'
+import { Uint8ArrayList } from 'uint8arraylist'
 
 const domain = 'libp2p-testing'
 const codec = uint8arrayFromString('/libp2p/testdata')
@@ -22,11 +22,11 @@ class TestRecord implements Record {
   }
 
   marshal () {
-    return uint8arrayFromString(this.data)
+    return new Uint8ArrayList(uint8arrayFromString(this.data))
   }
 
   equals (other: Record) {
-    return uint8arrayEquals(this.marshal(), other.marshal())
+    return this.marshal().equals(other.marshal())
   }
 }
 
@@ -54,7 +54,7 @@ describe('Envelope', () => {
     expect(envelope).to.exist()
     expect(envelope.peerId.equals(peerId)).to.eql(true)
     expect(envelope.payloadType).to.equalBytes(payloadType)
-    expect(envelope.payload).to.equalBytes(payload)
+    expect(envelope.payload.subarray()).to.equalBytes(payload.subarray())
     expect(envelope.signature).to.equalBytes(signature)
   })
 


### PR DESCRIPTION
To support no-copy operations, update interfaces to use `Uint8ArrayList`s instead of `Uint8Array`s.